### PR TITLE
Add Iterator interface return type

### DIFF
--- a/src/BulkLoader/Sources/ArrayBulkLoaderSource.php
+++ b/src/BulkLoader/Sources/ArrayBulkLoaderSource.php
@@ -3,6 +3,7 @@
 namespace ilateral\SilverStripe\ImportExport\BulkLoader\Sources;
 
 use ArrayIterator;
+use Iterator;
 
 /**
  * Array Bulk Loader Source
@@ -18,7 +19,7 @@ class ArrayBulkLoaderSource extends BulkLoaderSource
         $this->data = $data;
     }
 
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         return new ArrayIterator($this->data);
     }

--- a/src/BulkLoader/Sources/BulkLoaderSource.php
+++ b/src/BulkLoader/Sources/BulkLoaderSource.php
@@ -3,11 +3,12 @@
 namespace ilateral\SilverStripe\ImportExport\BulkLoader\Sources;
 
 use IteratorAggregate;
+use Iterator;
 
 /**
  * An abstract source to bulk load records from.
  * Provides an iterator for retrieving records from.
- * 
+ *
  * Useful for holiding source configuration state.
  */
 abstract class BulkLoaderSource implements IteratorAggregate
@@ -18,5 +19,5 @@ abstract class BulkLoaderSource implements IteratorAggregate
      * Records are expected to be 1 dimensional key-value arrays.
      * @return Iterator
      */
-    abstract public function getIterator();
+    abstract public function getIterator(): Iterator;
 }

--- a/src/BulkLoader/Sources/CsvBulkLoaderSource.php
+++ b/src/BulkLoader/Sources/CsvBulkLoaderSource.php
@@ -6,6 +6,7 @@ use Goodby\CSV\Import\Standard\Interpreter;
 use Goodby\CSV\Import\Standard\Lexer;
 use Goodby\CSV\Import\Standard\LexerConfig;
 use ArrayIterator;
+use Iterator;
 
 /**
  * CSV file bulk loading source
@@ -73,11 +74,11 @@ class CsvBulkLoaderSource extends BulkLoaderSource
      * Get a new CSVParser using defined settings.
      * @return Iterator
      */
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         if (!file_exists($this->filepath)) {
             //TODO: throw exception instead?
-            return null;
+            return new ArrayIterator([]);
         }
         $header = $this->hasheader ? $this->getFirstRow() : null;
         $output = array();


### PR DESCRIPTION
When running `dev/build` a notice of a missing return type from the `getIterator` method was popping up. These changes resolve that. 